### PR TITLE
fix: align sprint running index filter with SprintStatus

### DIFF
--- a/server/TempoForge.Infrastructure/Data/TempoForgeDbContext.cs
+++ b/server/TempoForge.Infrastructure/Data/TempoForgeDbContext.cs
@@ -39,7 +39,7 @@ public class TempoForgeDbContext : DbContext
         sprint.ToTable("Sprints", t => t.HasCheckConstraint("CK_Sprints_Duration_Minutes", "\"DurationMinutes\" > 0"));
         sprint.HasIndex(x => x.Status)
             .HasDatabaseName("IX_Sprints_Running")
-            .HasFilter("\"Status\" = 0")
+            .HasFilter("\"Status\" = 1")
             .IsUnique();
 
         var quest = modelBuilder.Entity<Quest>();

--- a/server/TempoForge.Infrastructure/Migrations/20250918205522_FixSprintRunningIndex.Designer.cs
+++ b/server/TempoForge.Infrastructure/Migrations/20250918205522_FixSprintRunningIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TempoForge.Infrastructure.Data;
@@ -11,9 +12,11 @@ using TempoForge.Infrastructure.Data;
 namespace TempoForge.Infrastructure.Migrations
 {
     [DbContext(typeof(TempoForgeDbContext))]
-    partial class TempoForgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250918205522_FixSprintRunningIndex")]
+    partial class FixSprintRunningIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/TempoForge.Infrastructure/Migrations/20250918205522_FixSprintRunningIndex.cs
+++ b/server/TempoForge.Infrastructure/Migrations/20250918205522_FixSprintRunningIndex.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TempoForge.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixSprintRunningIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Sprints_Running",
+                table: "Sprints");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sprints_Running",
+                table: "Sprints",
+                column: "Status",
+                unique: true,
+                filter: "\"Status\" = 1");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Sprints_Running",
+                table: "Sprints");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sprints_Running",
+                table: "Sprints",
+                column: "Status",
+                unique: true,
+                filter: "\"Status\" = 0");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update the Sprint status filtered index to match `SprintStatus.Running`
- add an EF Core migration that recreates the filtered index with `Status = 1`
- refresh the DbContext model snapshot to capture the corrected filter

## Testing
- dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cc712a52f0832fa0ac8f41334d13dc