### PR TITLE
Align project UI with updated ProjectDto

### DIFF
--- a/client/tempoforge-web/src/api/projects.ts
+++ b/client/tempoforge-web/src/api/projects.ts
@@ -7,10 +7,9 @@ const api = axios.create({
 export interface Project {
   id: string;
   name: string;
-  track: number;
-  pinned: boolean;
   isFavorite: boolean;
   createdAt: string;
+  lastUsedAt: string | null;
 }
 
 export async function getProjects(favorites?: boolean): Promise<Project[]> {
@@ -24,18 +23,13 @@ export async function getFavoriteProjects(): Promise<Project[]> {
   return data;
 }
 
-export async function addProject(
-  name: string,
-  track: number,
-  isFavorite = false,
-  pinned = false,
-) {
-  await api.post("/api/projects", { name, track, pinned, isFavorite });
+export async function addProject(name: string, isFavorite = false) {
+  await api.post("/api/projects", { name, isFavorite });
 }
 
 export async function updateProject(
   id: string,
-  patch: Partial<Pick<Project, "name" | "track" | "pinned" | "isFavorite">>,
+  patch: Partial<Pick<Project, "name" | "isFavorite">>,
 ) {
   await api.put(`/api/projects/${id}`, patch);
 }

--- a/client/tempoforge-web/src/components/daisyui/ProjectForm.tsx
+++ b/client/tempoforge-web/src/components/daisyui/ProjectForm.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 
-export type Track = "Work" | "Study";
-
 export type ProjectCreateInput = {
   name: string;
-  track: Track;
-  pinned: boolean;
+  isFavorite: boolean;
 };
 
 export function ProjectForm({
@@ -18,14 +15,15 @@ export function ProjectForm({
   submitting?: boolean;
 }) {
   const [name, setName] = React.useState(initial?.name ?? "");
-  const [track, setTrack] = React.useState<Track>(initial?.track ?? "Work");
-  const [pinned, setPinned] = React.useState<boolean>(initial?.pinned ?? false);
+  const [isFavorite, setIsFavorite] = React.useState<boolean>(
+    initial?.isFavorite ?? false,
+  );
   const [errors, setErrors] = React.useState<Record<string, string[]>>({});
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setErrors({});
-    await Promise.resolve(onSubmit({ name, track, pinned })).catch((err: any) => {
+    await Promise.resolve(onSubmit({ name, isFavorite })).catch((err: any) => {
       if (err?.status === 400 && err?.problemDetails) {
         setErrors(err.problemDetails.errors ?? {});
       } else {
@@ -50,18 +48,14 @@ export function ProjectForm({
       </div>
 
       <div className="form-control">
-        <label className="label"><span className="label-text">Track</span></label>
-        <select className="select select-bordered" value={track} onChange={e => setTrack(e.target.value as Track)}>
-          <option value="Work">Work</option>
-          <option value="Study">Study</option>
-        </select>
-        {errors["Track"] && <span className="text-error text-sm mt-1">{errors["Track"][0]}</span>}
-      </div>
-
-      <div className="form-control">
         <label className="cursor-pointer label justify-start gap-3">
-          <input type="checkbox" className="toggle" checked={pinned} onChange={e => setPinned(e.target.checked)} />
-          <span className="label-text">Pinned</span>
+          <input
+            type="checkbox"
+            className="toggle"
+            checked={isFavorite}
+            onChange={(e) => setIsFavorite(e.target.checked)}
+          />
+          <span className="label-text">Favorite</span>
         </label>
       </div>
 

--- a/client/tempoforge-web/src/components/daisyui/ProjectList.tsx
+++ b/client/tempoforge-web/src/components/daisyui/ProjectList.tsx
@@ -3,19 +3,35 @@ import React from "react";
 export type Project = {
   id: string;
   name: string;
-  track: "Work" | "Study";
-  pinned: boolean;
+  isFavorite: boolean;
   createdAt: string;
+  lastUsedAt: string | null;
+};
+
+const formatTimestamp = (
+  value: string | null | undefined,
+  emptyFallback: string,
+): string => {
+  if (!value) {
+    return emptyFallback;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "Unknown";
+  }
+
+  return parsed.toLocaleString();
 };
 
 export function ProjectList({
   items,
   onDelete,
-  onTogglePin,
+  onToggleFavorite,
 }: {
   items: Project[];
   onDelete?: (id: string) => void;
-  onTogglePin?: (id: string, pinned: boolean) => void;
+  onToggleFavorite?: (id: string, nextValue: boolean) => void;
 }) {
   if (!items?.length) {
     return <div className="alert shadow"><span>No projects yet.</span></div>;
@@ -28,13 +44,17 @@ export function ProjectList({
             <div className="flex items-center justify-between">
               <h3 className="card-title">
                 {p.name}
-                <span className="badge badge-outline ml-2">{p.track}</span>
-                {p.pinned && <span className="badge badge-primary ml-2">Pinned</span>}
+                {p.isFavorite && (
+                  <span className="badge badge-primary ml-2">Favorite</span>
+                )}
               </h3>
               <div className="flex gap-2">
-                {onTogglePin && (
-                  <button className="btn btn-xs" onClick={() => onTogglePin(p.id, !p.pinned)}>
-                    {p.pinned ? "Unpin" : "Pin"}
+                {onToggleFavorite && (
+                  <button
+                    className="btn btn-xs"
+                    onClick={() => onToggleFavorite(p.id, !p.isFavorite)}
+                  >
+                    {p.isFavorite ? "Unfavorite" : "Favorite"}
                   </button>
                 )}
                 {onDelete && (
@@ -42,7 +62,12 @@ export function ProjectList({
                 )}
               </div>
             </div>
-            <p className="text-sm opacity-70">Created {new Date(p.createdAt).toLocaleString()}</p>
+            <p className="text-sm opacity-70">
+              Created {formatTimestamp(p.createdAt, "Unknown")}
+            </p>
+            <p className="text-sm opacity-70">
+              Last used {formatTimestamp(p.lastUsedAt, "Not used yet")}
+            </p>
           </div>
         </li>
       ))}

--- a/client/tempoforge-web/src/components/daisyui/QuickStartCard.tsx
+++ b/client/tempoforge-web/src/components/daisyui/QuickStartCard.tsx
@@ -15,11 +15,7 @@ type QuickStartCardProps = {
   sprintStarting?: boolean;
   onPlanSprint: (projectId: string | null, durationMinutes: number) => void;
   onStartSprint: (projectId: string, durationMinutes: number) => Promise<void>;
-  onAddProject: (
-    name: string,
-    track: number,
-    isFavorite: boolean,
-  ) => Promise<void>;
+  onAddProject: (name: string, isFavorite: boolean) => Promise<void>;
   onToggleFavorite: (projectId: string, nextValue: boolean) => Promise<void>;
 };
 
@@ -105,10 +101,8 @@ export default function QuickStartCard({
     if (!name) {
       return;
     }
-    const trackValue = window.prompt("Track (1 = Work, 2 = Study)", "1") ?? "1";
-    const track = Number.parseInt(trackValue, 10) === 2 ? 2 : 1;
     const favorite = window.confirm("Mark as favorite?");
-    await onAddProject(name, track, favorite);
+    await onAddProject(name, favorite);
   }, [onAddProject]);
 
   const handleToggleFavorite = React.useCallback(
@@ -245,33 +239,39 @@ export default function QuickStartCard({
                 </div>
               ) : (
                 <ul className="divide-y divide-base-100/25">
-                  {projects.map((project) => (
-                    <li
-                      key={project.id}
-                      className="flex items-center justify-between py-2"
-                    >
-                      <button
-                        type="button"
-                        className={`text-left ${selectedProjectId === project.id ? "font-semibold text-yellow-200" : ""}`}
-                        onClick={() => handleSelectProject(project.id)}
+                  {projects.map((project) => {
+                    const lastUsed = project.lastUsedAt
+                      ? new Date(project.lastUsedAt).toLocaleString()
+                      : "Not used yet";
+                    return (
+                      <li
+                        key={project.id}
+                        className="flex items-center justify-between py-2"
                       >
-                        {project.name}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleToggleFavorite(project)}
-                        aria-label="Toggle favorite"
-                      >
-                        <Droplet
-                          className={
-                            project.isFavorite
-                              ? "text-red-600"
-                              : "text-gray-500 hover:text-red-500"
-                          }
-                        />
-                      </button>
-                    </li>
-                  ))}
+                        <button
+                          type="button"
+                          className={`text-left ${selectedProjectId === project.id ? "font-semibold text-yellow-200" : ""}`}
+                          onClick={() => handleSelectProject(project.id)}
+                        >
+                          <div>{project.name}</div>
+                          <div className="text-xs opacity-60">Last used {lastUsed}</div>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleToggleFavorite(project)}
+                          aria-label="Toggle favorite"
+                        >
+                          <Droplet
+                            className={
+                              project.isFavorite
+                                ? "text-red-600"
+                                : "text-gray-500 hover:text-red-500"
+                            }
+                          />
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </div>

--- a/client/tempoforge-web/src/main.tsx
+++ b/client/tempoforge-web/src/main.tsx
@@ -15,7 +15,7 @@ console.log("API base:", import.meta.env.VITE_API_BASE_URL);
 function Projects() {
   const [items, setItems] = React.useState<Project[]>([]);
   const [name, setName] = React.useState("");
-  const [track, setTrack] = React.useState<number>(1);
+  const [isFavorite, setIsFavorite] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | null>(null);
 
   const load = React.useCallback(() => {
@@ -35,9 +35,10 @@ function Projects() {
     setError(null);
     try {
       if (!name) return;
-      await addProject(name, track);
+      await addProject(name, isFavorite);
       setItems(await getProjects());
       setName("");
+      setIsFavorite(false);
     } catch (err: any) {
       setError(err?.response?.data?.title ?? "Failed to add project");
     }
@@ -53,14 +54,15 @@ function Projects() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <select
-          className="select select-bordered"
-          value={track}
-          onChange={(e) => setTrack(Number(e.target.value))}
-        >
-          <option value={1}>Work</option>
-          <option value={2}>Study</option>
-        </select>
+        <label className="label cursor-pointer gap-2">
+          <span className="label-text">Favorite</span>
+          <input
+            type="checkbox"
+            className="toggle"
+            checked={isFavorite}
+            onChange={(e) => setIsFavorite(e.target.checked)}
+          />
+        </label>
         <button className="btn btn-primary" type="submit">
           Add
         </button>
@@ -68,9 +70,17 @@ function Projects() {
       {error && <div className="alert alert-error mb-4">{error}</div>}
       <ul className="space-y-2">
         {items.map((p) => (
-          <li key={p.id} className="card bg-neutral text-neutral-content p-3">
-            <span className="font-semibold">{p.name}</span>{" "}
-            <span className="badge ml-2">Track {p.track}</span>
+          <li key={p.id} className="card bg-neutral text-neutral-content p-3 space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">{p.name}</span>
+              {p.isFavorite && <span className="badge badge-primary">Favorite</span>}
+            </div>
+            <div className="text-xs opacity-70">
+              Created {new Date(p.createdAt).toLocaleString()}
+            </div>
+            <div className="text-xs opacity-70">
+              Last used {p.lastUsedAt ? new Date(p.lastUsedAt).toLocaleString() : "Not used yet"}
+            </div>
           </li>
         ))}
       </ul>

--- a/client/tempoforge-web/src/pages/HudPage.tsx
+++ b/client/tempoforge-web/src/pages/HudPage.tsx
@@ -33,6 +33,7 @@ export default function HudPage(): JSX.Element {
     completeSprint,
   } = useSprintContext();
   const { setLayout } = useUserSettings();
+  const showLayoutToggle = typeof setLayout === "function";
   const handleReturnToDashboard = React.useCallback(() => {
     setLayout("daisyui");
   }, [setLayout]);


### PR DESCRIPTION
## Summary
- update client API typings to match the backend ProjectDto shape and drop unused track/pin fields
- refresh project creation, list, and quick start components to focus on favorites and timestamp details
- clean up the /projects page and HUD layout toggle guard to keep the build green

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7148c354832f9d4c5c7ee8c55209