### PR TITLE
chore: fix api dockerfile path in docker compose

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -12,7 +12,7 @@
   api:
     build:
       context: ..
-      dockerfile: TempoForge.Api/Dockerfile
+      dockerfile: server/TempoForge.Api/Dockerfile
     environment:
       ConnectionStrings__Default: Host=db;Database=tempo;Username=tempo;Password=tempo
       ClientOrigin: http://localhost:5173


### PR DESCRIPTION
## Summary
- update the API service definition to reference the Dockerfile under server/TempoForge.Api

## Testing
- docker compose build api *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc71550444832fbbb46f2ef58633af