### PR TITLE
Refactor project API consumers to match new DTO

### DIFF
--- a/client/tempoforge-web/src/api/projects.ts
+++ b/client/tempoforge-web/src/api/projects.ts
@@ -12,6 +12,16 @@ export interface Project {
   lastUsedAt: string | null;
 }
 
+export interface ProjectCreateRequest {
+  name: string;
+  isFavorite?: boolean;
+}
+
+export interface ProjectUpdateRequest {
+  name?: string;
+  isFavorite?: boolean;
+}
+
 export async function getProjects(favorites?: boolean): Promise<Project[]> {
   const query = favorites ? "?favorites=true" : "";
   const { data } = await api.get<Project[]>(`/api/projects${query}`);
@@ -23,15 +33,33 @@ export async function getFavoriteProjects(): Promise<Project[]> {
   return data;
 }
 
-export async function addProject(name: string, isFavorite = false) {
-  await api.post("/api/projects", { name, isFavorite });
+export async function addProject({
+  name,
+  isFavorite = false,
+}: ProjectCreateRequest) {
+  const payload: ProjectCreateRequest = {
+    name,
+    isFavorite,
+  };
+
+  await api.post("/api/projects", payload);
 }
 
 export async function updateProject(
   id: string,
-  patch: Partial<Pick<Project, "name" | "isFavorite">>,
+  patch: ProjectUpdateRequest,
 ) {
-  await api.put(`/api/projects/${id}`, patch);
+  const payload: ProjectUpdateRequest = {};
+
+  if (typeof patch.name === "string") {
+    payload.name = patch.name;
+  }
+
+  if (typeof patch.isFavorite === "boolean") {
+    payload.isFavorite = patch.isFavorite;
+  }
+
+  await api.put(`/api/projects/${id}`, payload);
 }
 
 export async function deleteProject(id: string) {

--- a/client/tempoforge-web/src/components/daisyui/ProjectList.tsx
+++ b/client/tempoforge-web/src/components/daisyui/ProjectList.tsx
@@ -1,12 +1,7 @@
 import React from "react";
+import type { Project } from "../../api/projects";
 
-export type Project = {
-  id: string;
-  name: string;
-  isFavorite: boolean;
-  createdAt: string;
-  lastUsedAt: string | null;
-};
+export type { Project };
 
 const formatTimestamp = (
   value: string | null | undefined,

--- a/client/tempoforge-web/src/components/daisyui/QuickStartCard.tsx
+++ b/client/tempoforge-web/src/components/daisyui/QuickStartCard.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { Droplet } from "lucide-react";
-import type { Project } from "../../api/projects";
+import type {
+  Project,
+  ProjectCreateRequest,
+} from "../../api/projects";
 
 type DurationOption = number | "custom";
 
@@ -15,7 +18,7 @@ type QuickStartCardProps = {
   sprintStarting?: boolean;
   onPlanSprint: (projectId: string | null, durationMinutes: number) => void;
   onStartSprint: (projectId: string, durationMinutes: number) => Promise<void>;
-  onAddProject: (name: string, isFavorite: boolean) => Promise<void>;
+  onAddProject: (input: ProjectCreateRequest) => Promise<void>;
   onToggleFavorite: (projectId: string, nextValue: boolean) => Promise<void>;
 };
 
@@ -102,7 +105,7 @@ export default function QuickStartCard({
       return;
     }
     const favorite = window.confirm("Mark as favorite?");
-    await onAddProject(name, favorite);
+    await onAddProject({ name, isFavorite: favorite });
   }, [onAddProject]);
 
   const handleToggleFavorite = React.useCallback(

--- a/client/tempoforge-web/src/main.tsx
+++ b/client/tempoforge-web/src/main.tsx
@@ -35,7 +35,7 @@ function Projects() {
     setError(null);
     try {
       if (!name) return;
-      await addProject(name, isFavorite);
+      await addProject({ name, isFavorite });
       setItems(await getProjects());
       setName("");
       setIsFavorite(false);

--- a/client/tempoforge-web/src/pages/DashboardPage.tsx
+++ b/client/tempoforge-web/src/pages/DashboardPage.tsx
@@ -14,7 +14,10 @@ import {
   type Project as ProjectListItem,
 } from "../components/daisyui/ProjectList";
 import { useSprintContext } from "../context/SprintContext";
-import type { Project as ProjectDto } from "../api/projects";
+import type {
+  Project as ProjectDto,
+  ProjectCreateRequest,
+} from "../api/projects";
 import {
   getProjects,
   getFavoriteProjects,
@@ -247,8 +250,8 @@ function DashboardPage(): JSX.Element {
   );
 
   const handleQuickAddProject = React.useCallback(
-    async (name: string, isFavorite: boolean) => {
-      await addProject(name, isFavorite);
+    async ({ name, isFavorite = false }: ProjectCreateRequest) => {
+      await addProject({ name, isFavorite });
       await Promise.all([loadProjects(), loadFavorites()]);
     },
     [loadFavorites, loadProjects],
@@ -271,7 +274,7 @@ function DashboardPage(): JSX.Element {
     async ({ name, isFavorite }: ProjectCreateInput) => {
       setProjectSubmitting(true);
       try {
-        await addProject(name, isFavorite);
+        await addProject({ name, isFavorite });
         await Promise.all([loadProjects(), loadFavorites()]);
       } finally {
         setProjectSubmitting(false);

--- a/client/tempoforge-web/src/pages/HudPage.tsx
+++ b/client/tempoforge-web/src/pages/HudPage.tsx
@@ -9,7 +9,7 @@ import { useSprintContext } from "../context/SprintContext";
 import { useUserSettings } from "../context/UserSettingsContext";
 
 export default function HudPage(): JSX.Element {
-  const showLayoutToggle = import.meta.env.DEV;
+  const allowLayoutToggle = import.meta.env.DEV;
   const {
     portalState,
     active,
@@ -34,7 +34,8 @@ export default function HudPage(): JSX.Element {
     completeSprint,
   } = useSprintContext();
   const { setLayout } = useUserSettings();
-  const showLayoutToggle = typeof setLayout === "function";
+  const showLayoutToggle =
+    allowLayoutToggle && typeof setLayout === "function";
   const handleReturnToDashboard = React.useCallback(() => {
     setLayout("daisyui");
   }, [setLayout]);


### PR DESCRIPTION
## Summary
- align the frontend project API types with the server DTO and sanitize create/update payloads
- update dashboard quick start, project list/form, and the projects page to consume the new API shape and favorites metadata
- guard the HUD layout toggle behind the dev flag to avoid duplicate declarations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7614a490832f95b1d1d80decd5c9