### PR TITLE
docs: finalize mvp readiness docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ npm run dev
 - Vite dev server defaults to `http://localhost:5173`.
 
 ### Environment Variables
-- `ConnectionStrings__Default` — Neon Postgres connection string for the API.
-- `VITE_API_BASE_URL` — Base URL the client uses to call the API (e.g., `http://localhost:5000`).
+- `ConnectionStrings__Default` â€” Neon Postgres connection string for the API.
+- `VITE_API_BASE_URL` â€” Base URL the client uses to call the API (e.g., `http://localhost:5000`).
 - Configure via `.env`, `dotnet user-secrets`, or Fly.io secret stores; never commit credentials.
 
 ## Containerized Workflow
@@ -135,6 +135,7 @@ docker run --rm -p 4173:4173 --env VITE_API_BASE_URL="http://localhost:5000" tem
   dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj
   ```
   Includes TestContainers coverage for sprint lifecycle + favorites, and QuestService in-memory unit tests.
+  The integration harness's [`ApiTestFixture`](server/TempoForge.Tests/Infrastructure/ApiTestFixture.cs) truncates the `Projects`, `Sprints`, and `Quests` tables before each run via `ResetDatabaseAsync`, which keeps the filtered unique index on running sprints (`Status = 1`) from colliding with stale rows. When adding new integration specs, call `ResetDatabaseAsync(reseed: true)` to repopulate the baseline data; the index is configured in [`TempoForgeDbContext`](server/TempoForge.Infrastructure/Data/TempoForgeDbContext.cs).
 - Verify the frontend build (type-check + production bundle):
   ```bash
   cd client/tempoforge-web
@@ -142,8 +143,8 @@ docker run --rm -p 4173:4173 --env VITE_API_BASE_URL="http://localhost:5000" tem
   ```
 
 ## Screenshots & Demo Media
-- ![TempoForge Dashboard — DaisyUI (default)](docs/screenshots/dashboard.png)
-- ![TempoForge Immersive HUD — Experimental](docs/screenshots/hud.png)
+- ![TempoForge Dashboard â€” DaisyUI (default)](docs/screenshots/dashboard.png)
+- ![TempoForge Immersive HUD â€” Experimental](docs/screenshots/hud.png)
 
 > Placeholder captures ship in `docs/screenshots/`. Replace them with live captures before public release.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.0] ñ 2025-09-18
+## [1.0.0] ‚Äì 2025-09-18
 
 ### Added
 - API: `/api/stats/*` endpoints now backed by `StatsService` with quest-aware summaries.
@@ -15,12 +15,18 @@
 - Sprint completion now advances daily/weekly/epic quests via `QuestService` and excludes aborted runs from streak/minute stats.
 - Dashboard grid unified (QuickStart, Stats, Progress, Favorites, Recent) with skeleton loaders; HUD stats panel shows lifetime totals.
 
+### Fixed
+- Database uniqueness filter now targets running sprints (`Status = 1`), preventing false conflicts when scheduling sessions.
+- HUD toggle guard stops null reference crashes when switching between dashboard and immersive modes.
+- Project UI and DTO contract stay in sync by using only `name`, `isFavorite`, `createdAt`, and `lastUsedAt` fields.
+- Docker Compose builds the API from `server/TempoForge.Api/Dockerfile`, aligning local stacks with the production image.
+
 ### Removed
 - Legacy quest CRUD references replaced with consolidated active/claim pipeline.
 
 ---
 
-## [0.2.1] ñ 2025-09-18
+## [0.2.1] ‚Äì 2025-09-18
 
 ### Added
 - docs: Reworked docs/PROJECTDESCRIPTION.md into a structured internal project brief covering scope, timeline, and workflow.
@@ -35,7 +41,7 @@ Following [Conventional Commits](https://www.conventionalcommits.org).
 
 ---
 
-## [0.2.0] ñ 2025-09-17
+## [0.2.0] ‚Äì 2025-09-17
 
 ### Added
 - Repo structure finalized under `/server`, `/client`, `/ops` for full-stack workflow.
@@ -44,7 +50,7 @@ Following [Conventional Commits](https://www.conventionalcommits.org).
 - Created and applied initial EF Core migration `InitProjects` to Neon DB.
 - Projects feature end-to-end:
   - Domain entity: `Project` (Id, Name, Track, Pinned, CreatedAt).
-  - Application service: `ProjectService` with CRUD + validation (name 3ñ80, track required).
+  - Application service: `ProjectService` with CRUD + validation (name 3‚Äì80, track required).
   - API controller: `ProjectsController` with GET/POST/PUT/DELETE.
   - Swagger/OpenAPI includes Projects endpoints.
 - Frontend scaffolding:
@@ -65,12 +71,12 @@ Following [Conventional Commits](https://www.conventionalcommits.org).
 
 ---
 
-## [0.2.0] ñ 2025-09-15
+## [0.2.0] ‚Äì 2025-09-15
 
 ### Added
 - **API**
   - ProjectsController with CRUD endpoints: GET/POST/PUT/DELETE /api/projects.
-  - DTO validation (name 3ñ80 chars, track required). Returns ProblemDetails on invalid input.
+  - DTO validation (name 3‚Äì80 chars, track required). Returns ProblemDetails on invalid input.
   - Swagger docs updated to include Projects endpoints.
 - **Domain/Infrastructure**
   - Project entity (Id, Name, Track, Pinned, CreatedAt).
@@ -89,7 +95,7 @@ Following [Conventional Commits](https://www.conventionalcommits.org).
 
 ---
 
-## [0.1.0] ñ 2025-09-15
+## [0.1.0] ‚Äì 2025-09-15
 
 ### Added
 - **Architecture**
@@ -113,7 +119,7 @@ Following [Conventional Commits](https://www.conventionalcommits.org).
     - CI: GitHub Actions workflow to build API, run **Testcontainers** tests, and build client.
 
 ### Changed
-- Moved backend projects into `/server` folder (aligns with Alexís ìserver/clientî convention).
+- Moved backend projects into `/server` folder (aligns with Alex‚Äôs ‚Äúserver/client‚Äù convention).
 - Cleaned `TempoForge.sln` to remove root-level project references.
 - Updated client to use `.env.development` for API base URL.
 - Fixed `vite.config.ts` by adding `@vitejs/plugin-react`.

--- a/docs/sql/Projects.sql
+++ b/docs/sql/Projects.sql
@@ -4,12 +4,15 @@
 CREATE TABLE "Projects" (
     "Id" uuid NOT NULL,
     "Name" character varying(80) NOT NULL,
-    "Track" integer NOT NULL,
-    "Pinned" boolean NOT NULL DEFAULT FALSE,
-    "CreatedAt" timestamp with time zone NOT NULL
+    "IsFavorite" boolean NOT NULL DEFAULT FALSE,
+    "CreatedAt" timestamptz NOT NULL,
+    "LastUsedAt" timestamptz NULL
 );
 
 ALTER TABLE "Projects"
     ADD CONSTRAINT "PK_Projects" PRIMARY KEY ("Id");
 
-CREATE INDEX "IX_Projects_Track" ON "Projects" ("Track"); 
+-- Support favorites filter + recents ordering
+CREATE INDEX "IX_Projects_IsFavorite" ON "Projects" ("IsFavorite");
+CREATE INDEX "IX_Projects_LastUsedAt" ON "Projects" ("LastUsedAt");
+


### PR DESCRIPTION
## Summary
- add a Fixed section to the 1.0.0 changelog entry covering sprint index, HUD guard, project UI, and compose fixes
- refresh the projects reference DDL to match the current schema and indexes
- expand the testing instructions with TestContainers cleanup and index guidance

## Testing
- dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc76bbd17c832faee7468ed87b3ba3