### PR TITLE
Handle empty-state responses and automate Fly deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,19 @@ jobs:
           DOTNET_RUNNING_IN_CONTAINER: "false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
         run: dotnet test --no-build -v n --no-parallel
+
+      - name: Setup Flyctl
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy API
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          cd server/TempoForge.Api
+          flyctl deploy --app tempoforge-api --remote-only
+
+      - name: Deploy Web
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          cd client/tempoforge-web
+          flyctl deploy --app tempoforge-web --remote-only

--- a/client/tempoforge-web/src/api/sprints.ts
+++ b/client/tempoforge-web/src/api/sprints.ts
@@ -126,13 +126,6 @@ export async function abortSprintRequest(id: string): Promise<SprintDto> {
 }
 
 export async function getRunningSprint(): Promise<SprintDto | null> {
-  try {
-    const { data } = await http.get<SprintDto>('/api/sprints/running')
-    return data
-  } catch (error: unknown) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) {
-      return null
-    }
-    throw error
-  }
+  const { data } = await http.get<SprintDto | null>('/api/sprints/running')
+  return data ?? null
 }

--- a/server/TempoForge.Api/Controllers/SprintsController.cs
+++ b/server/TempoForge.Api/Controllers/SprintsController.cs
@@ -115,16 +115,10 @@ public class SprintsController : ControllerBase
     /// </summary>
     [HttpGet("running")]
     [ProducesResponseType(typeof(SprintDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<SprintDto>> GetRunning(CancellationToken ct)
+    public async Task<ActionResult<SprintDto?>> GetRunning(CancellationToken ct)
     {
         var sprint = await _service.GetRunningAsync(ct);
-        if (sprint is null)
-        {
-            return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", "No sprint is currently running."));
-        }
-
-        return Ok(SprintDto.From(sprint));
+        return Ok(sprint is null ? null : SprintDto.From(sprint));
     }
 
     /// <summary>

--- a/server/TempoForge.Api/fly.toml
+++ b/server/TempoForge.Api/fly.toml
@@ -2,7 +2,7 @@ app = 'tempoforge-api'
 primary_region = 'cdg'
 
 [build]
-  dockerfile = "server/TempoForge.Api/Dockerfile"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8080

--- a/server/TempoForge.Tests/EmptyStateApiTests.cs
+++ b/server/TempoForge.Tests/EmptyStateApiTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Json;
+using TempoForge.Domain.Entities;
+using TempoForge.Tests.Infrastructure;
+using Xunit;
+
+namespace TempoForge.Tests;
+
+public class EmptyStateApiTests : IClassFixture<ApiTestFixture>
+{
+    private readonly ApiTestFixture _fixture;
+
+    public EmptyStateApiTests(ApiTestFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task EmptyDatabase_ReturnsOkWithEmptyPayloads()
+    {
+        if (!_fixture.DockerAvailable) return;
+
+        await _fixture.ResetDatabaseAsync();
+
+        using var client = _fixture.CreateClient();
+
+        var favoritesResponse = await client.GetAsync("/api/projects/favorites");
+        Assert.Equal(HttpStatusCode.OK, favoritesResponse.StatusCode);
+        var favorites = await favoritesResponse.Content.ReadFromJsonAsync<List<ProjectFavoritesResponse>>();
+        Assert.NotNull(favorites);
+        Assert.Empty(favorites!);
+
+        var recentResponse = await client.GetAsync("/api/sprints/recent");
+        Assert.Equal(HttpStatusCode.OK, recentResponse.StatusCode);
+        var recent = await recentResponse.Content.ReadFromJsonAsync<List<RecentSprintResponse>>();
+        Assert.NotNull(recent);
+        Assert.Empty(recent!);
+
+        var todayResponse = await client.GetAsync("/api/stats/today");
+        Assert.Equal(HttpStatusCode.OK, todayResponse.StatusCode);
+        var today = await todayResponse.Content.ReadFromJsonAsync<TodayStatsResponse>();
+        Assert.NotNull(today);
+        Assert.Equal(0, today!.Minutes);
+        Assert.Equal(0, today.Sprints);
+        Assert.Equal(0, today.StreakDays);
+
+        var progressResponse = await client.GetAsync("/api/stats/progress");
+        Assert.Equal(HttpStatusCode.OK, progressResponse.StatusCode);
+        var progress = await progressResponse.Content.ReadFromJsonAsync<ProgressResponse>();
+        Assert.NotNull(progress);
+        Assert.Equal(0, progress!.TotalCompleted);
+        Assert.NotNull(progress.Quest);
+        Assert.True(progress.PercentToNext >= 0);
+
+        var runningResponse = await client.GetAsync("/api/sprints/running");
+        Assert.Equal(HttpStatusCode.OK, runningResponse.StatusCode);
+        var running = await runningResponse.Content.ReadFromJsonAsync<SprintResponse?>();
+        Assert.Null(running);
+    }
+
+    private sealed record ProjectFavoritesResponse(Guid Id, bool IsFavorite);
+    private sealed record RecentSprintResponse(Guid Id, string ProjectName, int DurationMinutes, DateTime StartedAtUtc, SprintStatus Status);
+    private sealed record TodayStatsResponse(int Minutes, int Sprints, int StreakDays);
+    private sealed record QuestSnapshotResponse(int DailyGoal, int DailyCompleted, int WeeklyGoal, int WeeklyCompleted, int EpicGoal, int EpicCompleted);
+    private sealed record ProgressResponse(string Standing, int PercentToNext, int TotalCompleted, int? NextThreshold, QuestSnapshotResponse Quest);
+    private sealed record SprintResponse(Guid Id, Guid ProjectId, string ProjectName, int DurationMinutes, DateTime StartedAtUtc, DateTime? CompletedAtUtc, DateTime? AbortedAtUtc, SprintStatus Status);
+}


### PR DESCRIPTION
## Summary
- return HTTP 200 with empty payloads for favorites, recent sprints, stats, and running sprint requests and add an integration test to cover the empty database case
- seed baseline data on startup, parse multiple client origins for CORS, and align the API Fly configuration with the project layout
- simplify the web client's running sprint fetch and update CI to deploy both the API and frontend to Fly.io when main builds succeed

## Testing
- `dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd91ef6a4832f8671e2658d4cf9c1