### PR TITLE
ci: fix dotnet test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           DOTNET_RUNNING_IN_CONTAINER: "false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
-        run: dotnet test --no-build -v n --no-parallel
+        run: dotnet test --no-build --verbosity normal
 
       - name: Setup Flyctl
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/server/TempoForge.Tests/AssemblyInfo.cs
+++ b/server/TempoForge.Tests/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/server/TempoForge.Tests/Properties/AssemblyInfo.cs
+++ b/server/TempoForge.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary
- update the CI workflow to call `dotnet test` without the deprecated `--no-parallel` flag
- configure the test assembly to disable parallelization via xUnit attributes so the workflow remains serial

## Testing
- dotnet test --no-build --verbosity normal *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cddc5aaeb0832fa861b38306918014