### PR TITLE
chore(ci): ensure tests run before fly deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --no-restore -c Release
+        run: dotnet build TempoForge.sln --configuration Release --no-restore
 
-      - name: Test with Testcontainers
+      - name: Run tests
         env:
           DOTNET_RUNNING_IN_CONTAINER: "false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test TempoForge.sln --no-build --verbosity normal
 
       - name: Setup Flyctl
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- run the solution build with an explicit Release configuration before deploy steps
- execute the test suite against the solution so it finishes prior to any Fly deployment

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cddf9f0530832fa623ffd914788b19