### PR TITLE
Separate Fly deploy from CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,23 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
         run: dotnet test --no-build --verbosity normal
 
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build-test.result == 'success'
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Setup Flyctl
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy API
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           cd server/TempoForge.Api
           flyctl deploy --app tempoforge-api --remote-only
 
       - name: Deploy Web
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           cd client/tempoforge-web
           flyctl deploy --app tempoforge-web --remote-only


### PR DESCRIPTION
## Summary
- keep .NET restore/build/test on the Actions runner ahead of any deployments
- move Fly deployments into a dedicated job that only runs for successful pushes to main

## Testing
- ⚠️ `dotnet test --no-build --verbosity minimal` *(fails in container: `dotnet` command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68cde06b97d4832fbb16d4e041051041