### PR TITLE
chore: remove fly build hooks from fly.io apps

### DIFF
--- a/client/tempoforge-web/fly.toml
+++ b/client/tempoforge-web/fly.toml
@@ -1,9 +1,6 @@
 app = "tempoforge-web"
 primary_region = "cdg"
 
-[build]
-  dockerfile = "Dockerfile"
-
 [env]
   VITE_API_BASE_URL = "https://tempoforge-api.fly.dev"
 

--- a/server/TempoForge.Api/fly.toml
+++ b/server/TempoForge.Api/fly.toml
@@ -1,9 +1,6 @@
 app = 'tempoforge-api'
 primary_region = 'cdg'
 
-[build]
-  dockerfile = "Dockerfile"
-
 [http_service]
   internal_port = 8080
   force_https = true


### PR DESCRIPTION
## Summary
- remove the Fly.io [build] hooks so deploys no longer run Dockerfile builds locally
- ensure CI remains responsible for running dotnet test and Fly deploys only execute flyctl deploy

## Testing
- ⚠️ `dotnet test TempoForge.sln --no-build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cde1c3bfac832fa495786225ea1bca