### PR TITLE
chore(ci): run tests against release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Restore
         run: dotnet restore
 
-      - name: Build
+      - name: Build solution
         run: dotnet build TempoForge.sln --configuration Release --no-restore
 
-      - name: Backend tests
+      - name: Run backend tests
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"
-        run: dotnet test TempoForge.sln --no-build --verbosity normal
+        run: dotnet test TempoForge.sln --no-build --configuration Release --verbosity normal
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- rename the build step to clarify its purpose
- execute backend tests using the release configuration to avoid invalid DLL errors

## Testing
- not run (workflow update only)

------
https://chatgpt.com/codex/tasks/task_e_68ce78dd6e64832fabe84483eef7415e