### PR TITLE
fix: stabilize backend seeding and tests

### DIFF
--- a/server/TempoForge.Api/Controllers/ProjectsController.cs
+++ b/server/TempoForge.Api/Controllers/ProjectsController.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using TempoForge.Application.Projects;
+using TempoForge.Domain.Entities;
 
 namespace TempoForge.Api.Controllers;
 
@@ -41,8 +43,9 @@ public class ProjectsController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<ProjectDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<ProjectDto>>> GetFavorites(CancellationToken ct)
     {
-        var favorites = await _service.GetFavoritesAsync(ct);
-        return Ok(favorites.Select(ProjectDto.From));
+        var favorites = await _service.GetFavoritesAsync(ct) ?? new List<Project>();
+        var projection = favorites.Select(ProjectDto.From).ToList();
+        return Ok(projection);
     }
 
     /// <summary>

--- a/server/TempoForge.Api/Controllers/QuestsController.cs
+++ b/server/TempoForge.Api/Controllers/QuestsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using TempoForge.Application.Quests;
 
 namespace TempoForge.Api.Controllers;
@@ -21,7 +22,10 @@ public class QuestsController : ControllerBase
     [HttpGet("active")]
     [ProducesResponseType(typeof(List<QuestDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<QuestDto>>> GetActive(CancellationToken ct)
-        => Ok(await _service.GetActiveAsync(ct));
+    {
+        var quests = await _service.GetActiveAsync(ct) ?? new List<QuestDto>();
+        return Ok(quests);
+    }
 
     /// <summary>
     /// Retrieves the active quest entities grouped by type for reward tracking.
@@ -29,7 +33,10 @@ public class QuestsController : ControllerBase
     [HttpGet("active/details")]
     [ProducesResponseType(typeof(ActiveQuestsDto), StatusCodes.Status200OK)]
     public async Task<ActionResult<ActiveQuestsDto>> GetDetailedActive(CancellationToken ct)
-        => Ok(await _service.GetActiveQuestsAsync(ct));
+    {
+        var quests = await _service.GetActiveQuestsAsync(ct);
+        return Ok(quests ?? new ActiveQuestsDto(null, null, null));
+    }
 
     /// <summary>
     /// Marks a quest reward as claimed once its goal has been met.

--- a/server/TempoForge.Api/Controllers/StatsController.cs
+++ b/server/TempoForge.Api/Controllers/StatsController.cs
@@ -25,7 +25,7 @@ public class StatsController : ControllerBase
     public async Task<ActionResult<TodayStatsDto>> GetToday(CancellationToken ct)
     {
         var stats = await _statsService.GetTodayStatsAsync(ct);
-        return Ok(stats);
+        return Ok(stats ?? new TodayStatsDto(0, 0, 0));
     }
 
     /// <summary>
@@ -36,6 +36,6 @@ public class StatsController : ControllerBase
     public async Task<ActionResult<ProgressDto>> GetProgress(CancellationToken ct)
     {
         var stats = await _statsService.GetProgressAsync(ct);
-        return Ok(stats);
+        return Ok(stats ?? new ProgressDto("Bronze", 0, 0, null, new QuestSnapshot(0, 0, 0, 0, 0, 0)));
     }
 }

--- a/server/TempoForge.Application/Sprints/Dtos.cs
+++ b/server/TempoForge.Application/Sprints/Dtos.cs
@@ -7,8 +7,8 @@ namespace TempoForge.Application.Sprints;
 /// Request payload used to start a new sprint for a project.
 /// </summary>
 public record StartSprintRequest(
-    [property: Required] Guid ProjectId,
-    [property: Range(1, 180)] int DurationMinutes
+    [Required] Guid ProjectId,
+    [Range(1, 180)] int DurationMinutes
 );
 
 /// <summary>

--- a/server/TempoForge.Infrastructure/Data/TempoForgeSeeder.cs
+++ b/server/TempoForge.Infrastructure/Data/TempoForgeSeeder.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
 using TempoForge.Domain.Entities;
 
 namespace TempoForge.Infrastructure.Data;
@@ -11,17 +13,23 @@ public static class TempoForgeSeeder
 
     public static async Task SeedAsync(TempoForgeDbContext db, CancellationToken ct = default)
     {
-        await SeedProjectsAsync(db, ct);
-        await SeedQuestsAsync(db, ct);
-    }
+        ArgumentNullException.ThrowIfNull(db);
 
-    private static async Task SeedProjectsAsync(TempoForgeDbContext db, CancellationToken ct)
-    {
-        if (await db.Projects.AnyAsync(ct))
+        var hasProjects = await db.Projects.AnyAsync(ct);
+        var hasQuests = await db.Quests.AnyAsync(ct);
+        var hasSprints = await db.Sprints.AnyAsync(ct);
+
+        if (hasProjects || hasQuests || hasSprints)
         {
             return;
         }
 
+        await SeedProjectsAndSprintsAsync(db, ct);
+        await SeedQuestsAsync(db, ct);
+    }
+
+    private static async Task SeedProjectsAndSprintsAsync(TempoForgeDbContext db, CancellationToken ct)
+    {
         var now = DateTime.UtcNow;
         var todayMorning = ToUtc(now.Date.AddHours(8));
         var yesterday = ToUtc(todayMorning.AddDays(-1));

--- a/server/TempoForge.Tests/EndToEndApiTests.cs
+++ b/server/TempoForge.Tests/EndToEndApiTests.cs
@@ -14,12 +14,12 @@ public class EndToEndApiTests : IClassFixture<ApiTestFixture>
     public EndToEndApiTests(ApiTestFixture fixture)
     {
         _fixture = fixture;
+        _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
     }
 
     [Fact]
     public async Task SprintLifecycle_UpdatesProgressStats()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Lifecycle Project");
 
@@ -37,7 +37,6 @@ public class EndToEndApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task ToggleFavorite_PersistsInFavoritesEndpoint()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var projectId = await CreateProjectAsync(client, "Favorite Toggle", isFavorite: false);

--- a/server/TempoForge.Tests/QuestsApiTests.cs
+++ b/server/TempoForge.Tests/QuestsApiTests.cs
@@ -15,12 +15,15 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
 {
     private readonly ApiTestFixture _fixture;
 
-    public QuestsApiTests(ApiTestFixture fixture) => _fixture = fixture;
+    public QuestsApiTests(ApiTestFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
+    }
 
     [Fact]
     public async Task ActiveQuests_ReturnsSeededDefinitions()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var response = await client.GetAsync("/api/quests/active/details");
@@ -39,7 +42,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task CompletingSprint_AdvancesDailyWeeklyAndEpic()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Quest Progress");
 
@@ -56,7 +58,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task DailyQuest_ResetsWhenExpired()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Daily Reset");
 
@@ -80,7 +81,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task WeeklyQuest_ResetsAtNextWeekBoundary()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Weekly Reset");
 
@@ -104,7 +104,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task EpicQuest_PersistsAcrossResets()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Epic Persistence");
 
@@ -133,7 +132,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task ClaimQuestReward_ReturnsConflictWhenIncomplete()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var quests = await client.GetFromJsonAsync<ActiveQuestsResponse>("/api/quests/active/details");
@@ -146,7 +144,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task ClaimQuestReward_SucceedsOnceGoalReached()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Quest Claim");
 
@@ -171,7 +168,6 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task QuestsEndpoint_ReturnsAggregatedProgress()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Aggregated Quests");
 

--- a/server/TempoForge.Tests/SprintsApiTests.cs
+++ b/server/TempoForge.Tests/SprintsApiTests.cs
@@ -13,12 +13,15 @@ namespace TempoForge.Tests;
 public class SprintsApiTests : IClassFixture<ApiTestFixture>
 {
     private readonly ApiTestFixture _fixture;
-    public SprintsApiTests(ApiTestFixture fixture) => _fixture = fixture;
+    public SprintsApiTests(ApiTestFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
+    }
 
     [Fact]
     public async Task StartSprint_ReturnsCreated()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Alpha");
@@ -33,7 +36,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task StartSprint_WhenRunning_ReturnsConflict()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Conflict Project");
@@ -52,7 +54,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task CompleteSprint_UpdatesStatusAndStats()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Completion Project");
@@ -75,7 +76,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task AbortSprint_DoesNotAffectStats()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Abort Project");
@@ -96,7 +96,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task RecentSprints_ReturnsMostRecentEntries()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var alpha = await CreateProjectAsync(client, "Alpha Project");
@@ -122,7 +121,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task Progress_ReturnsSilverStandingWithPercent()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Progress Project");
@@ -144,7 +142,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task StartingSprint_UpdatesProjectLastUsed()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
         var projectId = await CreateProjectAsync(client, "Chronos");
@@ -164,7 +161,6 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task ToggleFavoritesEndpoint_ReflectsUpdatedFlag()
     {
-        await _fixture.ResetDatabaseAsync();
         // Arrange + Act + Assert
         using var client = _fixture.CreateClient();
 

--- a/server/TempoForge.Tests/StatsApiTests.cs
+++ b/server/TempoForge.Tests/StatsApiTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http.Json;
 using TempoForge.Domain.Entities;
@@ -14,12 +14,12 @@ public class StatsApiTests : IClassFixture<ApiTestFixture>
     public StatsApiTests(ApiTestFixture fixture)
     {
         _fixture = fixture;
+        _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
     }
 
     [Fact]
     public async Task TodayStats_ReturnsMinutesSprintsAndStreak()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var response = await client.GetAsync("/api/stats/today");
@@ -35,7 +35,6 @@ public class StatsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task ProgressStats_ReturnsStandingAndQuestSnapshot()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var response = await client.GetAsync("/api/stats/progress");
@@ -52,19 +51,18 @@ public class StatsApiTests : IClassFixture<ApiTestFixture>
     [Fact]
     public async Task FavoritesEndpoint_ReturnsOnlyFavorites()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var favorites = await client.GetFromJsonAsync<List<ProjectResponse>>("/api/projects/favorites");
         Assert.NotNull(favorites);
-        Assert.NotEmpty(favorites!);
-        Assert.All(favorites!, project => Assert.True(project.isFavorite));
+        var favoriteList = favorites!;
+        Assert.Single(favoriteList);
+        Assert.True(favoriteList[0].isFavorite);
     }
 
     [Fact]
     public async Task RecentSprintsEndpoint_ReturnsLatestFiveWithProjectNames()
     {
-        await _fixture.ResetDatabaseAsync();
         using var client = _fixture.CreateClient();
 
         var results = await client.GetFromJsonAsync<List<RecentSprintResponse>>("/api/sprints/recent");


### PR DESCRIPTION
## Summary
- move sprint start validation attributes onto the record parameters
- normalize read endpoints to always return 200 OK with empty arrays/objects and guard stats/quest projections
- prevent duplicate seeding and reset the database per integration test while updating empty-state expectations

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce84f98998832f89b2ececb73ccebd