### PR TITLE
fix(frontend): add manifest and local api default

### DIFF
--- a/client/tempoforge-web/public/site.webmanifest
+++ b/client/tempoforge-web/public/site.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "TempoForge",
+  "short_name": "TempoForge",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#110805",
+  "theme_color": "#d4af37",
+  "icons": [
+    {
+      "src": "/assets/logo-primary.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/logo-primary-no-arms-no-background-no-clock-background.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
+      "purpose": "maskable any"
+    }
+  ]
+}

--- a/client/tempoforge-web/src/config.ts
+++ b/client/tempoforge-web/src/config.ts
@@ -1,4 +1,19 @@
-export const FALLBACK_API_BASE = 'https://tempoforge-api.fly.dev'
+const REMOTE_API_BASE = 'https://tempoforge-api.fly.dev'
+const LOCAL_API_BASE = 'http://localhost:5000'
+
+const inferFallbackBase = (): string => {
+  if (typeof window !== 'undefined') {
+    const { hostname } = window.location
+
+    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+      return LOCAL_API_BASE
+    }
+  }
+
+  return REMOTE_API_BASE
+}
+
+export const FALLBACK_API_BASE = inferFallbackBase()
 
 function normalizeBaseUrl(value: unknown): string {
   if (typeof value !== 'string') {

--- a/client/tempoforge-web/tsconfig.json
+++ b/client/tempoforge-web/tsconfig.json
@@ -10,7 +10,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true
+    "strict": true,
+    "types": ["vitest/globals", "vitest/importMeta"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add a `site.webmanifest` so browsers stop requesting a missing asset
- default the frontend to the local API when developing on localhost while keeping the remote fallback for deployed builds
- register Vitest globals in TypeScript configuration so the build step recognizes test helpers

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cead692c40832f8e786bde2e86fb67