### PR TITLE
refactor(api): centralize problem detail responses

### DIFF
--- a/server/TempoForge.Api/Controllers/ProjectsController.cs
+++ b/server/TempoForge.Api/Controllers/ProjectsController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using TempoForge.Api;
 using TempoForge.Application.Projects;
 using TempoForge.Domain.Entities;
 
@@ -59,7 +60,7 @@ public class ProjectsController : ControllerBase
         var project = await _service.GetAsync(id, ct);
         if (project is null)
         {
-            return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Project not found", $"Project '{id}' was not found."));
+            return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Project not found", $"Project '{id}' was not found."));
         }
 
         return Ok(ProjectDto.From(project));
@@ -88,7 +89,7 @@ public class ProjectsController : ControllerBase
         var updated = await _service.UpdateAsync(id, dto, ct);
         if (updated is null)
         {
-            return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Project not found", $"Project '{id}' was not found."));
+            return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Project not found", $"Project '{id}' was not found."));
         }
 
         return Ok(ProjectDto.From(updated));
@@ -105,18 +106,10 @@ public class ProjectsController : ControllerBase
         var deleted = await _service.DeleteAsync(id, ct);
         if (!deleted)
         {
-            return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Project not found", $"Project '{id}' was not found."));
+            return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Project not found", $"Project '{id}' was not found."));
         }
 
         return NoContent();
     }
 
-    private ProblemDetails CreateProblem(int statusCode, string title, string detail)
-        => new()
-        {
-            Title = title,
-            Status = statusCode,
-            Detail = detail,
-            Instance = HttpContext.Request.Path
-        };
 }

--- a/server/TempoForge.Api/Controllers/QuestsController.cs
+++ b/server/TempoForge.Api/Controllers/QuestsController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using TempoForge.Api;
 using TempoForge.Application.Quests;
 
 namespace TempoForge.Api.Controllers;
@@ -52,23 +53,15 @@ public class QuestsController : ControllerBase
             var quest = await _service.ClaimRewardAsync(id, ct);
             if (quest is null)
             {
-                return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Quest not found", $"Quest '{id}' was not found."));
+                return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Quest not found", $"Quest '{id}' was not found."));
             }
 
             return Ok(quest);
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(CreateProblem(StatusCodes.Status409Conflict, "Quest not yet completed", ex.Message));
+            return Conflict(this.CreateProblem(StatusCodes.Status409Conflict, "Quest not yet completed", ex.Message));
         }
     }
 
-    private ProblemDetails CreateProblem(int statusCode, string title, string detail)
-        => new()
-        {
-            Title = title,
-            Status = statusCode,
-            Detail = detail,
-            Instance = HttpContext.Request.Path
-        };
 }

--- a/server/TempoForge.Api/Controllers/SprintsController.cs
+++ b/server/TempoForge.Api/Controllers/SprintsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using TempoForge.Api;
 using TempoForge.Application.Sprints;
 using TempoForge.Domain.Entities;
 
@@ -32,7 +33,7 @@ public class SprintsController : ControllerBase
         var sprint = await _service.GetAsync(id, ct);
         if (sprint is null)
         {
-            return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", $"Sprint '{id}' was not found."));
+            return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", $"Sprint '{id}' was not found."));
         }
 
         return Ok(SprintDto.From(sprint));
@@ -54,11 +55,11 @@ public class SprintsController : ControllerBase
         }
         catch (KeyNotFoundException ex)
         {
-            return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Project not found", ex.Message));
+            return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Project not found", ex.Message));
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(CreateProblem(StatusCodes.Status409Conflict, "Sprint already running", ex.Message));
+            return Conflict(this.CreateProblem(StatusCodes.Status409Conflict, "Sprint already running", ex.Message));
         }
     }
 
@@ -76,14 +77,14 @@ public class SprintsController : ControllerBase
             var sprint = await _service.CompleteAsync(id, ct);
             if (sprint is null)
             {
-                return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", $"Sprint '{id}' was not found."));
+                return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", $"Sprint '{id}' was not found."));
             }
 
             return Ok(SprintDto.From(sprint));
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(CreateProblem(StatusCodes.Status409Conflict, "Sprint cannot be completed", ex.Message));
+            return Conflict(this.CreateProblem(StatusCodes.Status409Conflict, "Sprint cannot be completed", ex.Message));
         }
     }
 
@@ -101,14 +102,14 @@ public class SprintsController : ControllerBase
             var sprint = await _service.AbortAsync(id, ct);
             if (sprint is null)
             {
-                return NotFound(CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", $"Sprint '{id}' was not found."));
+                return NotFound(this.CreateProblem(StatusCodes.Status404NotFound, "Sprint not found", $"Sprint '{id}' was not found."));
             }
 
             return Ok(SprintDto.From(sprint));
         }
         catch (InvalidOperationException ex)
         {
-            return Conflict(CreateProblem(StatusCodes.Status409Conflict, "Sprint cannot be aborted", ex.Message));
+            return Conflict(this.CreateProblem(StatusCodes.Status409Conflict, "Sprint cannot be aborted", ex.Message));
         }
     }
 
@@ -140,14 +141,6 @@ public class SprintsController : ControllerBase
         return Ok(projection);
     }
 
-    private ProblemDetails CreateProblem(int statusCode, string title, string detail)
-        => new()
-        {
-            Title = title,
-            Status = statusCode,
-            Detail = detail,
-            Instance = HttpContext.Request.Path
-        };
 }
 
 

--- a/server/TempoForge.Api/ProblemDetailsExtensions.cs
+++ b/server/TempoForge.Api/ProblemDetailsExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TempoForge.Api;
+
+public static class ProblemDetailsExtensions
+{
+    public static ProblemDetails CreateProblem(
+        this ControllerBase controller,
+        int statusCode,
+        string title,
+        string detail,
+        string? instance = null)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+
+        var requestPath = controller.HttpContext?.Request?.Path.Value;
+
+        return new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance ?? requestPath
+        };
+    }
+}

--- a/server/TempoForge.Tests/ProblemDetailsExtensionsTests.cs
+++ b/server/TempoForge.Tests/ProblemDetailsExtensionsTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using TempoForge.Api;
+using Xunit;
+
+namespace TempoForge.Tests;
+
+public class ProblemDetailsExtensionsTests
+{
+    [Fact]
+    public void CreateProblem_UsesRequestPathWhenInstanceNotProvided()
+    {
+        var controller = new TestController("/quests/123");
+
+        var problem = controller.CreateProblem(StatusCodes.Status404NotFound, "Missing", "Quest not found");
+
+        Assert.Equal(StatusCodes.Status404NotFound, problem.Status);
+        Assert.Equal("Missing", problem.Title);
+        Assert.Equal("Quest not found", problem.Detail);
+        Assert.Equal("/quests/123", problem.Instance);
+    }
+
+    [Fact]
+    public void CreateProblem_UsesProvidedInstanceWhenSupplied()
+    {
+        var controller = new TestController("/quests/123");
+
+        var problem = controller.CreateProblem(
+            StatusCodes.Status409Conflict,
+            "Conflict",
+            "Quest already claimed",
+            "/custom-instance");
+
+        Assert.Equal("/custom-instance", problem.Instance);
+    }
+
+    private sealed class TestController : ControllerBase
+    {
+        public TestController(string path)
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = path;
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = context
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `ProblemDetailsExtensions` helper so controllers can create consistent problem responses
- update projects, sprints, and quests controllers to rely on the shared helper while preserving existing messaging
- cover the helper with tests to confirm default request path behavior and optional instance overrides

## Testing
- dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb5dbb010832fa8768c416e2e45cb