### PR TITLE
refactor: use quest service abstraction in API

### DIFF
--- a/server/TempoForge.Api/Controllers/QuestsController.cs
+++ b/server/TempoForge.Api/Controllers/QuestsController.cs
@@ -11,9 +11,9 @@ namespace TempoForge.Api.Controllers;
 [Route("api/[controller]")]
 public class QuestsController : ControllerBase
 {
-    private readonly QuestService _service;
+    private readonly IQuestService _service;
 
-    public QuestsController(QuestService service)
+    public QuestsController(IQuestService service)
         => _service = service;
 
     /// <summary>

--- a/server/TempoForge.Api/Program.cs
+++ b/server/TempoForge.Api/Program.cs
@@ -43,7 +43,6 @@ builder.Services.AddDbContext<TempoForgeDbContext>(o =>
 });
 builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IQuestService, QuestService>();
-builder.Services.AddScoped<QuestService>();
 builder.Services.AddScoped<ISprintService, SprintService>();
 builder.Services.AddScoped<IStatsService, StatsService>();
 


### PR DESCRIPTION
## Summary
- update the quests controller to depend on the IQuestService abstraction
- remove the redundant QuestService-only registration from the API service container

## Testing
- `dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb5e069d8832faa4c24240962f2e0