### PR TITLE
test: isolate integration data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ docker run --rm -p 4173:4173 --env VITE_API_BASE_URL="http://localhost:5000" tem
   dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj
   ```
   Includes TestContainers coverage for sprint lifecycle + favorites, and QuestService in-memory unit tests.
-  The integration harness's [`ApiTestFixture`](server/TempoForge.Tests/Infrastructure/ApiTestFixture.cs) truncates the `Projects`, `Sprints`, and `Quests` tables before each run via `ResetDatabaseAsync`, which keeps the filtered unique index on running sprints (`Status = 1`) from colliding with stale rows. When adding new integration specs, call `ResetDatabaseAsync(reseed: true)` to repopulate the baseline data; the index is configured in [`TempoForgeDbContext`](server/TempoForge.Infrastructure/Data/TempoForgeDbContext.cs).
+  The integration harness's [`ApiTestFixture`](server/TempoForge.Tests/Infrastructure/ApiTestFixture.cs) truncates the `Projects`, `Sprints`, and `Quests` tables before each run via `ResetDatabaseAsync`, which keeps the filtered unique index on running sprints (`Status = 1`) from colliding with stale rows. When adding new integration specs, call `ResetDatabaseAsync()` to clear the database and use `SeedTestDataAsync()` if you need the shared baseline quests/projects for your scenario; the index is configured in [`TempoForgeDbContext`](server/TempoForge.Infrastructure/Data/TempoForgeDbContext.cs).
 - Verify the frontend build (type-check + production bundle):
   ```bash
   cd client/tempoforge-web

--- a/server/TempoForge.Api/Program.cs
+++ b/server/TempoForge.Api/Program.cs
@@ -71,7 +71,12 @@ app.Lifetime.ApplicationStarted.Register(() =>
         {
             var db = scope.ServiceProvider.GetRequiredService<TempoForgeDbContext>();
             await db.Database.MigrateAsync();
-            DataSeeder.Seed(db);
+
+            if (app.Environment.IsDevelopment() || app.Environment.IsProduction())
+            {
+                DataSeeder.Seed(db, app.Environment);
+            }
+
             if (app.Environment.IsDevelopment())
             {
                 await TempoForgeSeeder.SeedAsync(db);

--- a/server/TempoForge.Infrastructure/Data/DataSeeder.cs
+++ b/server/TempoForge.Infrastructure/Data/DataSeeder.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Hosting;
 using TempoForge.Domain.Entities;
 
 namespace TempoForge.Infrastructure.Data;
@@ -18,9 +19,15 @@ public static class DataSeeder
     public static readonly Guid EpicMasterSortingQuestId = Guid.Parse("4C34537C-C8BA-4EA0-A182-7AF68C9486AE");
     public static readonly Guid EpicDeployDemoQuestId = Guid.Parse("991DD330-9976-43E5-BF3C-F7E7FED5E210");
 
-    public static void Seed(TempoForgeDbContext context)
+    public static void Seed(TempoForgeDbContext context, IHostEnvironment hostEnvironment)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(hostEnvironment);
+
+        if (hostEnvironment.IsEnvironment("Test"))
+        {
+            return;
+        }
 
         var referenceUtc = DateTime.UtcNow;
         var hasChanges = false;

--- a/server/TempoForge.Tests/EmptyStateApiTests.cs
+++ b/server/TempoForge.Tests/EmptyStateApiTests.cs
@@ -15,7 +15,7 @@ public class EmptyStateApiTests : IClassFixture<ApiTestFixture>
     public EmptyStateApiTests(ApiTestFixture fixture)
     {
         _fixture = fixture;
-        _fixture.ResetDatabaseAsync(reseed: false).GetAwaiter().GetResult();
+        _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
     }
 
     [Fact]

--- a/server/TempoForge.Tests/QuestsApiTests.cs
+++ b/server/TempoForge.Tests/QuestsApiTests.cs
@@ -19,6 +19,7 @@ public class QuestsApiTests : IClassFixture<ApiTestFixture>
     {
         _fixture = fixture;
         _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
+        _fixture.SeedTestDataAsync().GetAwaiter().GetResult();
     }
 
     [Fact]

--- a/server/TempoForge.Tests/StatsApiTests.cs
+++ b/server/TempoForge.Tests/StatsApiTests.cs
@@ -15,6 +15,7 @@ public class StatsApiTests : IClassFixture<ApiTestFixture>
     {
         _fixture = fixture;
         _fixture.ResetDatabaseAsync().GetAwaiter().GetResult();
+        _fixture.SeedTestDataAsync().GetAwaiter().GetResult();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- skip the infrastructure data seeder when the host environment is Test
- only invoke demo seeding during development/production startup and expose a fixture helper for test data
- update integration specs and docs to reset to an empty database unless they explicitly seed data

## Testing
- `dotnet test --no-build --configuration Release --verbosity normal` *(fails: dotnet CLI is unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb88b12d8832f891d13e2eb2735f7