### PR TITLE
test(architecture): migrate checks to ArchUnitNET

### DIFF
--- a/server/TempoForge.Tests.Architecture/TempoForge.Tests.Architecture.csproj
+++ b/server/TempoForge.Tests.Architecture/TempoForge.Tests.Architecture.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageReference Include="TngTech.ArchUnitNET.xUnit" Version="0.12.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- replace the NetArchTest dependency with the ArchUnitNET.xUnit package for architecture tests
- rewrite the architecture tests to use the ArchUnitNET fixture pattern and fluent rules while cleaning obsolete helpers

## Testing
- dotnet test server/TempoForge.Tests.Architecture/TempoForge.Tests.Architecture.csproj *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb89864fc832fb29bb23fcf6775cc