### PR TITLE
feat: centralize frontend axios client

### DIFF
--- a/client/tempoforge-web/src/api/__tests__/http.test.ts
+++ b/client/tempoforge-web/src/api/__tests__/http.test.ts
@@ -1,0 +1,31 @@
+import { vi } from 'vitest'
+import http from '../http'
+import { API_BASE } from '../../config'
+
+describe('shared http client', () => {
+  it('uses the configured base URL and JSON header', () => {
+    expect(http.defaults.baseURL).toBe(API_BASE)
+    expect(http.defaults.headers.common['Content-Type']).toBe('application/json')
+  })
+
+  it('logs failed requests in development environments', async () => {
+    const handlers = (http.interceptors.response as unknown as {
+      handlers: Array<{ rejected?: (reason: unknown) => unknown }>
+    }).handlers
+
+    const rejectHandler = handlers[0]?.rejected
+    expect(typeof rejectHandler).toBe('function')
+
+    const originalDev = import.meta.env.DEV
+    ;(import.meta.env as unknown as Record<string, unknown>).DEV = true
+
+    const error = new Error('boom')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect((rejectHandler as (reason: unknown) => unknown)(error)).rejects.toThrow(error)
+    expect(consoleSpy).toHaveBeenCalledWith('API request failed', error)
+
+    consoleSpy.mockRestore()
+    ;(import.meta.env as unknown as Record<string, unknown>).DEV = originalDev
+  })
+})

--- a/client/tempoforge-web/src/api/http.ts
+++ b/client/tempoforge-web/src/api/http.ts
@@ -1,0 +1,22 @@
+import axios from 'axios'
+import { API_BASE } from '../config'
+
+const http = axios.create({
+  baseURL: API_BASE,
+})
+
+http.defaults.headers.common['Content-Type'] = 'application/json'
+
+http.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error('API request failed', error)
+    }
+
+    return Promise.reject(error)
+  },
+)
+
+export default http

--- a/client/tempoforge-web/src/api/projects.ts
+++ b/client/tempoforge-web/src/api/projects.ts
@@ -1,9 +1,4 @@
-import axios from 'axios'
-import { API_BASE } from '../config'
-
-const api = axios.create({
-  baseURL: API_BASE,
-})
+import http from './http'
 
 export interface Project {
   id: string
@@ -25,12 +20,12 @@ export interface ProjectUpdateRequest {
 
 export async function getProjects(favorites?: boolean): Promise<Project[]> {
   const query = favorites ? '?favorites=true' : ''
-  const { data } = await api.get<Project[]>(`/api/projects${query}`)
+  const { data } = await http.get<Project[]>(`/api/projects${query}`)
   return data
 }
 
 export async function getFavoriteProjects(): Promise<Project[]> {
-  const { data } = await api.get<Project[]>(`/api/projects/favorites`)
+  const { data } = await http.get<Project[]>(`/api/projects/favorites`)
   return data
 }
 
@@ -43,7 +38,7 @@ export async function addProject({
     isFavorite,
   }
 
-  await api.post('/api/projects', payload)
+  await http.post('/api/projects', payload)
 }
 
 export async function updateProject(id: string, patch: ProjectUpdateRequest) {
@@ -57,9 +52,9 @@ export async function updateProject(id: string, patch: ProjectUpdateRequest) {
     payload.isFavorite = patch.isFavorite
   }
 
-  await api.put(`/api/projects/${id}`, payload)
+  await http.put(`/api/projects/${id}`, payload)
 }
 
 export async function deleteProject(id: string) {
-  await api.delete(`/api/projects/${id}`)
+  await http.delete(`/api/projects/${id}`)
 }

--- a/client/tempoforge-web/src/api/quests.ts
+++ b/client/tempoforge-web/src/api/quests.ts
@@ -1,7 +1,4 @@
-import axios from 'axios'
-import { API_BASE } from '../config'
-
-const http = axios.create({ baseURL: API_BASE })
+import http from './http'
 
 export type QuestType = 'Daily' | 'Weekly' | 'Epic'
 

--- a/client/tempoforge-web/src/api/sprints.ts
+++ b/client/tempoforge-web/src/api/sprints.ts
@@ -1,7 +1,4 @@
-import axios from 'axios'
-import { API_BASE } from '../config'
-
-const http = axios.create({ baseURL: API_BASE })
+import http from './http'
 
 export type SprintDto = {
   id: string


### PR DESCRIPTION
## Summary
- add a shared Axios HTTP client with base URL configuration and development-time error logging
- update the project, quest, and sprint API modules to consume the shared client for consistent behavior
- cover the shared client with a unit test verifying configuration and interceptor logging

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ceb9f1ff40832fb1f0b69e5786f0b5