### PR TITLE
feat: add reusable modal wrapper for DaisyUI dialogs

### DIFF
--- a/client/tempoforge-web/src/components/daisyui/AddProjectModal.tsx
+++ b/client/tempoforge-web/src/components/daisyui/AddProjectModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { createPortal } from "react-dom";
 import type { ProjectCreateRequest } from "../../api/projects";
+import ModalShell from "./ModalShell";
 
 type AddProjectModalProps = {
   isOpen: boolean;
@@ -38,45 +38,7 @@ export default function AddProjectModal({
     setError(null);
   }, [isOpen]);
 
-  React.useEffect(() => {
-    if (!isOpen || typeof document === "undefined") {
-      return undefined;
-    }
-
-    const { body } = document;
-    const previousOverflow = body.style.overflow;
-    body.classList.add("modal-open");
-    body.style.overflow = "hidden";
-
-    return () => {
-      body.classList.remove("modal-open");
-      body.style.overflow = previousOverflow;
-    };
-  }, [isOpen]);
-
-  React.useEffect(() => {
-    if (!isOpen) {
-      return undefined;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        handleClose();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [handleClose, isOpen]);
-
   if (!isOpen) {
-    return null;
-  }
-
-  if (typeof document === "undefined") {
     return null;
   }
 
@@ -105,13 +67,15 @@ export default function AddProjectModal({
     }
   };
 
-  const modalContent = (
-    <div
-      className="modal modal-open"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      aria-describedby={error ? errorId : descriptionId}
+  const describedBy = error ? errorId : descriptionId;
+
+  return (
+    <ModalShell
+      open={isOpen}
+      onClose={handleClose}
+      labelledBy={titleId}
+      describedBy={describedBy}
+      lockBodyScroll
     >
       <div className="modal-box space-y-4 bg-base-200 text-base-content">
         <h2 id={titleId} className="text-lg font-semibold">
@@ -132,7 +96,7 @@ export default function AddProjectModal({
               autoFocus
               disabled={submitting}
               aria-invalid={error ? true : undefined}
-              aria-describedby={error ? errorId : descriptionId}
+              aria-describedby={describedBy}
             />
           </label>
 
@@ -172,9 +136,6 @@ export default function AddProjectModal({
           </div>
         </form>
       </div>
-      <div className="modal-backdrop bg-black/40" onClick={handleClose} role="presentation" />
-    </div>
+    </ModalShell>
   );
-
-  return createPortal(modalContent, document.body);
 }

--- a/client/tempoforge-web/src/components/daisyui/CustomDurationModal.tsx
+++ b/client/tempoforge-web/src/components/daisyui/CustomDurationModal.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ModalShell from "./ModalShell";
 
 type CustomDurationModalProps = {
   open: boolean;
@@ -39,24 +40,6 @@ export default function CustomDurationModal({
     }
   }, [initialMinutes, open]);
 
-  React.useEffect(() => {
-    if (!open) {
-      return undefined;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        handleClose();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [handleClose, open]);
-
   if (!open) {
     return null;
   }
@@ -80,12 +63,11 @@ export default function CustomDurationModal({
   const describedBy = error ? errorId : descriptionId;
 
   return (
-    <div
-      className="modal modal-open"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      aria-describedby={describedBy}
+    <ModalShell
+      open={open}
+      onClose={handleClose}
+      labelledBy={titleId}
+      describedBy={describedBy}
     >
       <div className="modal-box space-y-4 bg-base-200 text-base-content">
         <h2 id={titleId} className="text-lg font-semibold">
@@ -126,7 +108,6 @@ export default function CustomDurationModal({
           </div>
         </form>
       </div>
-      <div className="modal-backdrop bg-black/40" onClick={handleClose} role="presentation" />
-    </div>
+    </ModalShell>
   );
 }

--- a/client/tempoforge-web/src/components/daisyui/ModalShell.tsx
+++ b/client/tempoforge-web/src/components/daisyui/ModalShell.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { createPortal } from "react-dom";
+
+type ModalShellProps = {
+  open: boolean;
+  onClose?: () => void;
+  children: React.ReactNode;
+  labelledBy?: string;
+  describedBy?: string;
+  lockBodyScroll?: boolean;
+  className?: string;
+  backdropClassName?: string;
+  container?: Element | DocumentFragment | null;
+  disablePortal?: boolean;
+  closeOnEscape?: boolean;
+  closeOnBackdrop?: boolean;
+  role?: "dialog" | "alertdialog";
+};
+
+function joinClasses(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+export default function ModalShell({
+  open,
+  onClose,
+  children,
+  labelledBy,
+  describedBy,
+  lockBodyScroll = false,
+  className,
+  backdropClassName,
+  container,
+  disablePortal = false,
+  closeOnEscape = true,
+  closeOnBackdrop = true,
+  role = "dialog",
+}: ModalShellProps) {
+  const portalTarget = React.useMemo(() => {
+    if (disablePortal) {
+      return null;
+    }
+    if (container) {
+      return container;
+    }
+    if (typeof document === "undefined") {
+      return null;
+    }
+    return document.body;
+  }, [container, disablePortal]);
+
+  React.useEffect(() => {
+    if (!open || !lockBodyScroll) {
+      return undefined;
+    }
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.classList.add("modal-open");
+    body.style.overflow = "hidden";
+
+    return () => {
+      body.classList.remove("modal-open");
+      body.style.overflow = previousOverflow;
+    };
+  }, [lockBodyScroll, open]);
+
+  React.useEffect(() => {
+    if (!open || !closeOnEscape || !onClose) {
+      return undefined;
+    }
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeOnEscape, onClose, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  if (!disablePortal && !portalTarget) {
+    return null;
+  }
+
+  const content = (
+    <div
+      className={joinClasses("modal", open && "modal-open", className)}
+      role={role}
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
+    >
+      {children}
+      <div
+        className={joinClasses("modal-backdrop bg-black/40", backdropClassName)}
+        onClick={closeOnBackdrop && onClose ? () => onClose() : undefined}
+        role="presentation"
+      />
+    </div>
+  );
+
+  if (disablePortal) {
+    return content;
+  }
+
+  return createPortal(content, portalTarget as Element | DocumentFragment);
+}


### PR DESCRIPTION
## Summary
- add a ModalShell component to centralize DaisyUI modal rendering, backdrop, escape handling, and optional scroll locking
- refactor AddProjectModal and CustomDurationModal to compose the shared shell while keeping their form logic intact

## Testing
- pnpm lint *(fails: ESLint 9 requires a flat config and the repo still relies on .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb9e7a564832f96055955c17e4804