### PR TITLE
Fix missing hosting abstractions dependency

### DIFF
--- a/server/TempoForge.Infrastructure/TempoForge.Infrastructure.csproj
+++ b/server/TempoForge.Infrastructure/TempoForge.Infrastructure.csproj
@@ -13,6 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TempoForge.Domain\TempoForge.Domain.csproj" />


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Hosting.Abstractions to the infrastructure project so `IHostEnvironment` resolves during builds

## Testing
- dotnet build TempoForge.sln --configuration Release --no-restore *(fails in container: `dotnet` command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68cebaf0ab84832fb5d6f06e1e01efbe