### PR TITLE
ci: set test environment for backend workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Run backend tests
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          ASPNETCORE_ENVIRONMENT: Test
+          DOTNET_ENVIRONMENT: Test
         run: dotnet test TempoForge.sln --no-build --configuration Release --verbosity normal
 
       - name: Setup Node


### PR DESCRIPTION
## Summary
- set ASPNETCORE_ENVIRONMENT and DOTNET_ENVIRONMENT to Test when running backend tests in CI to avoid production seeding

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cecbb50cbc832fbd237e072e30344f