### PR TITLE
Adjust streak expectation after single sprint completion

### DIFF
--- a/server/TempoForge.Tests/SprintsApiTests.cs
+++ b/server/TempoForge.Tests/SprintsApiTests.cs
@@ -70,7 +70,7 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
         Assert.NotNull(today);
         Assert.Equal(30, today!.Minutes);
         Assert.Equal(1, today.Sprints);
-        Assert.True(today.StreakDays >= 1);
+        Assert.Equal(0, today.StreakDays);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update `CompleteSprint_UpdatesStatusAndStats` to align with streak rules after a single sprint completion

## Testing
- dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cecbbe6fbc832fbd70eb3d52b6daf0