### PR TITLE
fix: relax streak threshold for stats service

### DIFF
--- a/server/TempoForge.Application/Stats/StatsService.cs
+++ b/server/TempoForge.Application/Stats/StatsService.cs
@@ -8,6 +8,7 @@ namespace TempoForge.Application.Stats;
 public class StatsService : IStatsService
 {
     private const int DefaultDailyGoal = 3;
+    private const int MinimumDailyCompletionsForStreak = 1;
     private const int DefaultWeeklyGoal = 15;
     private const int DefaultEpicGoal = 100;
     private const int BronzeTarget = 20;
@@ -68,7 +69,8 @@ public class StatsService : IStatsService
 
         var cursor = startOfDayUtc;
         var streak = 0;
-        while (completionLookup.TryGetValue(cursor, out var dailyCount) && dailyCount >= DefaultDailyGoal)
+        while (completionLookup.TryGetValue(cursor, out var dailyCount) &&
+               dailyCount >= MinimumDailyCompletionsForStreak)
         {
             streak++;
             cursor = cursor.AddDays(-1);


### PR DESCRIPTION
## Summary
- add a dedicated minimum daily completion threshold for streak calculation
- treat any day with at least one completed sprint as streak-worthy to match updated expectations

## Testing
- `dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cecf5fc068832faa67d66f07a6fffd