### PR TITLE
fix: update streak calculations to count single completions

### DIFF
--- a/server/TempoForge.Application/Quests/QuestService.cs
+++ b/server/TempoForge.Application/Quests/QuestService.cs
@@ -165,7 +165,7 @@ public class QuestService : IQuestService
 
         var cursor = startOfDayUtc.Date;
         var streak = 0;
-        while (lookup.TryGetValue(cursor, out var dailyCount) && dailyCount >= DailyGoalTarget)
+        while (lookup.TryGetValue(cursor, out var dailyCount) && dailyCount >= 1)
         {
             streak++;
             cursor = cursor.AddDays(-1);

--- a/server/TempoForge.Application/Stats/StatsService.cs
+++ b/server/TempoForge.Application/Stats/StatsService.cs
@@ -68,7 +68,7 @@ public class StatsService : IStatsService
 
         var cursor = startOfDayUtc;
         var streak = 0;
-        while (completionLookup.TryGetValue(cursor, out var dailyCount) && dailyCount >= DefaultDailyGoal)
+        while (completionLookup.TryGetValue(cursor, out var dailyCount) && dailyCount >= 1)
         {
             streak++;
             cursor = cursor.AddDays(-1);


### PR DESCRIPTION
## Summary
- adjust the stats streak calculation to treat any day with at least one completed sprint as part of the streak
- mirror the one-sprint threshold in the quest streak calculation so the weekly streak quest aligns with stats

## Testing
- `dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced1d02c0c832f890cbd22634c8ab1