### PR TITLE
feat: count single sprint days in streak calculations

### DIFF
--- a/server/TempoForge.Application/Quests/QuestService.cs
+++ b/server/TempoForge.Application/Quests/QuestService.cs
@@ -11,6 +11,7 @@ public class QuestService : IQuestService
     private const int EpicGoalTarget = 100;
     private const int StreakGoalTarget = 5;
     private const int StreakLookbackDays = 30;
+    private const int MinimumDailyCompletionsForStreak = 1;
 
     private readonly TempoForgeDbContext _db;
 
@@ -165,7 +166,8 @@ public class QuestService : IQuestService
 
         var cursor = startOfDayUtc.Date;
         var streak = 0;
-        while (lookup.TryGetValue(cursor, out var dailyCount) && dailyCount >= DailyGoalTarget)
+        while (lookup.TryGetValue(cursor, out var dailyCount) &&
+               dailyCount >= MinimumDailyCompletionsForStreak)
         {
             streak++;
             cursor = cursor.AddDays(-1);

--- a/server/TempoForge.Application/Stats/StatsService.cs
+++ b/server/TempoForge.Application/Stats/StatsService.cs
@@ -8,7 +8,7 @@ namespace TempoForge.Application.Stats;
 public class StatsService : IStatsService
 {
     private const int DefaultDailyGoal = 3;
-    private const int MinimumDailyCompletionsForStreak = 1;
+    private const int MinimumDailyCompletionsForStreak = 1; // Any completed sprint counts toward streak progress.
     private const int DefaultWeeklyGoal = 15;
     private const int DefaultEpicGoal = 100;
     private const int BronzeTarget = 20;
@@ -67,7 +67,7 @@ public class StatsService : IStatsService
 
         var completionLookup = completionsByDay.ToDictionary(x => x.Date, x => x.Count);
 
-        var cursor = startOfDayUtc;
+        var cursor = startOfDayUtc.Date;
         var streak = 0;
         while (completionLookup.TryGetValue(cursor, out var dailyCount) &&
                dailyCount >= MinimumDailyCompletionsForStreak)


### PR DESCRIPTION
## Summary
- count any day with at least one completed sprint toward the streak in the stats service
- apply the same minimum completion rule to the weekly maintain-streak quest

## Testing
- `dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj` *(fails: `dotnet` command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced247b860832f99ceb250571595a5