### PR TITLE
ci: publish backend trx test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,25 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           ASPNETCORE_ENVIRONMENT: Test
           DOTNET_ENVIRONMENT: Test
-        run: dotnet test TempoForge.sln --no-build --configuration Release --verbosity normal
+        run: |
+          mkdir -p TestResults
+          dotnet test TempoForge.sln --no-build --configuration Release --verbosity normal \
+            --logger "trx;LogFileName=TestResults/backend-tests.trx"
+
+      - name: Upload backend test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-results
+          path: TestResults/backend-tests.trx
+
+      - name: Publish backend test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Backend Tests
+          path: TestResults/backend-tests.trx
+          reporter: dotnet-trx
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- update the backend test step to emit a TRX report into `TestResults/`
- upload the generated TRX file as a workflow artifact
- publish the structured test results to the Actions Tests tab with `dorny/test-reporter`

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cedbee4df4832f94f69346fe0bb578