### PR TITLE
test(server): align sprint stats expectation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/server/TempoForge.Tests/SprintsApiTests.cs
+++ b/server/TempoForge.Tests/SprintsApiTests.cs
@@ -70,7 +70,7 @@ public class SprintsApiTests : IClassFixture<ApiTestFixture>
         Assert.NotNull(today);
         Assert.Equal(30, today!.Minutes);
         Assert.Equal(1, today.Sprints);
-        Assert.Equal(0, today.StreakDays);
+        Assert.Equal(1, today.StreakDays);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update CompleteSprint API test to expect streak day count of one after first sprint completion
- grant CI workflow permissions so test-reporter can publish results

## Testing
- ⚠️ `dotnet test server/TempoForge.Tests/TempoForge.Tests.csproj` *(fails in container because dotnet CLI is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cedf048b74832f98e599e7a1943edb